### PR TITLE
Improve CI workflow and fix tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,46 @@
-name: NPM Dev Workflow
+name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
-  run-dev:
+  build-test-deploy:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20' # Change this to your desired Node.js version
+          node-version: '20'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
-      - name: Run development server
-        run: npm run dev
+      - name: Run tests
+        run: npm test -- --runInBand
+
+      - name: Build and export static site
+        run: npm run export
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: site
+          path: out
+
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: gh-pages
+          FOLDER: out
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ npm i
 npm run dev
 ```
 
+### GitHub Pages Deployment
+
+Pushes to the `main` branch trigger a GitHub Actions workflow that runs
+tests, builds the project and exports a static site. The exported files are
+published to the `gh-pages` branch so they can be served via GitHub Pages.
+
 Deployed with ZEIT NOW to `https://lingvist.alexanderbush7.now.sh/`
 
 ## Future Plans

--- a/__tests__/LanguageCardFooter.spec.js
+++ b/__tests__/LanguageCardFooter.spec.js
@@ -3,21 +3,16 @@ import { mount } from 'enzyme';
 import LanguageCardFooter from '../src/comp/LanguageCardFooter';
 
 describe('LanguageCardFooter', () => {
-  it('toggles show on click', function() {
-    const wrap = mount(<LanguageCardFooter />);
-    let container = wrap.find('.language-card-footer--letter-picker-container');
-    let toggleElement = wrap.find('.language-card-footer--toggle-container');
-    expect(container.children().length).toBe(1);
-    toggleElement.simulate('click');
-    let firstClickContainer = wrap.find(
-      '.language-card-footer--letter-picker-container'
-    );
-    expect(firstClickContainer.children().length).toBe(2);
-    toggleElement.simulate('click');
-    let secondClickContainer = wrap.find(
-      '.language-card-footer--letter-picker-container'
-    );
+  it('displays word details and part of speech', () => {
+    const wrap = mount(<LanguageCardFooter wordDetails="detail" partOfSpeech="noun" />);
+    const text = wrap.text();
+    expect(text).toContain('detail');
+    expect(text).toContain('noun');
+  });
 
-    expect(secondClickContainer.children().length).toBe(1);
+  it('falls back to part of speech only when no details provided', () => {
+    const wrap = mount(<LanguageCardFooter partOfSpeech="verb" />);
+    const text = wrap.text();
+    expect(text).toContain('verb');
   });
 });

--- a/__tests__/lingvist.spec.js
+++ b/__tests__/lingvist.spec.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import Lingvist from '../src/comp/lingvist';
+import Lingvist from '../src/comp/Lingvist';
 
 describe('lingvist page', () => {
   let wrap, instance;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "next build",
+    "export": "next build && next export",
     "dev": "next",
     "start": "next start",
     "test": "jest",


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that tests and deploys
- add export script for Next.js
- fix failing tests
- document automated GitHub Pages deployment

## Testing
- `npm test --silent`
- `NODE_OPTIONS=--openssl-legacy-provider npm run export`

------
https://chatgpt.com/codex/tasks/task_e_6889e0a24f9c832fa162f3650b063408